### PR TITLE
fix auth/session race condition, auto-refresh access token and dashboard race condition

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -11,10 +11,6 @@ export async function POST() {
     const accessToken = cookieStore.get('accessToken')?.value;
     const refreshToken = cookieStore.get('refreshToken')?.value;
 
-    if (accessToken) {
-      return NextResponse.json({ success: true });
-    }
-
     if (refreshToken) {
       const apiRes = await api.post('auth/refresh', null, {
         headers: {
@@ -45,6 +41,10 @@ export async function POST() {
         return NextResponse.json({ success: true }, { status: 200 });
       }
     }
+    if (accessToken) {
+      return NextResponse.json({ success: true });
+    }
+
     return NextResponse.json({ success: false }, { status: 200 });
   } catch (error) {
     if (isAxiosError(error)) {

--- a/components/dashboard/BabyTodayCard/BabyTodayCard.tsx
+++ b/components/dashboard/BabyTodayCard/BabyTodayCard.tsx
@@ -23,7 +23,7 @@ export default function BabyTodayCard({ initialWeekData }: Props) {
   } = useQuery({
     queryKey: ['weeks', 'me'],
     queryFn: getWeeksMe,
-    enabled: isAuthenticated,
+    enabled: !isInitializing && isAuthenticated,
   });
 
   const {
@@ -34,6 +34,7 @@ export default function BabyTodayCard({ initialWeekData }: Props) {
     queryKey: ['weeks', 'public', 1],
     queryFn: () => getPublicWeek(1),
     initialData: initialWeekData,
+    enabled: !isInitializing && !isAuthenticated,
   });
 
   const weekData = isAuthenticated ? currentWeek : publicWeek;

--- a/components/dashboard/MomTipCard/MomTipCard.tsx
+++ b/components/dashboard/MomTipCard/MomTipCard.tsx
@@ -9,14 +9,15 @@ import css from './MomTipCard.module.css';
 
 export default function MomTipCard() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isInitializing = useAuthStore((s) => s.isInitializing);
 
   const { data, isLoading } = useQuery<WeekDashboardInfo>({
     queryKey: ['weeks', isAuthenticated ? 'me' : 'public', 1],
-    queryFn: () =>
-      isAuthenticated ? getWeeksMe() : getPublicWeek(1),
+    queryFn: () => (isAuthenticated ? getWeeksMe() : getPublicWeek(1)),
+    enabled: !isInitializing,
   });
 
-  if (isLoading) {
+  if (isInitializing || isLoading) {
     return (
       <section className={css.card}>
         <p className={css.text}>Завантаження поради...</p>

--- a/components/dashboard/StatusBlock/StatusBlock.tsx
+++ b/components/dashboard/StatusBlock/StatusBlock.tsx
@@ -20,6 +20,7 @@ export default function StatusBlock() {
       }
       return getPublicWeek(WEEK_INDEX);
     },
+    enabled: !isInitializing,
   });
 
   if (isInitializing || isLoading) {

--- a/components/dashboard/TasksReminderCard/TasksReminderCard.tsx
+++ b/components/dashboard/TasksReminderCard/TasksReminderCard.tsx
@@ -17,16 +17,19 @@ const TasksReminderCard = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isInitializing = useAuthStore((s) => s.isInitializing);
 
   const { data: tasks = [] } = useQuery<Task[]>({
     queryKey: ['tasks'],
     queryFn: getTasks,
-    enabled: isAuthenticated,
+    enabled: !isInitializing && isAuthenticated,
     staleTime: 1000 * 60 * 2,
     refetchOnWindowFocus: false,
   });
 
   const handleCreate = () => {
+    if (isInitializing) return;
+
     if (isAuthenticated) {
       setIsModalOpen(true);
     } else {
@@ -60,6 +63,20 @@ const TasksReminderCard = () => {
 
     return [...active, ...done];
   }, [tasks]);
+
+  if (isInitializing) {
+    return (
+      <section className={css.card}>
+        <div className={css.cardHeader}>
+          <h2 className={css.tasksHeading}>Важливі завдання</h2>
+        </div>
+
+        <div className={css.cardContent}>
+          <p className={css.text}>Завантаження завдань...</p>
+        </div>
+      </section>
+    );
+  }
 
   if (!isAuthenticated) {
     return (

--- a/components/providers/AuthProvider.tsx
+++ b/components/providers/AuthProvider.tsx
@@ -17,17 +17,38 @@ const AuthProvider = ({ children }: Props) => {
 
   useEffect(() => {
     const fetchUser = async () => {
-      const session = await checkSession();
-      if (session.success) {
+      try {
+        const session = await checkSession();
+
+        if (!session.success) {
+          clearIsAuthenticated();
+          return;
+        }
+
         const user = await getMe();
-        if (user) setUser(user);
-      } else {
+
+        if (user) {
+          setUser(user);
+        } else {
+          clearIsAuthenticated();
+        }
+      } catch {
         clearIsAuthenticated();
+      } finally {
+        setInitialized();
       }
-      setInitialized();
     };
+
     fetchUser();
   }, [clearIsAuthenticated, setUser, setInitialized]);
+
+  useEffect(() => {
+    window.addEventListener('auth:session-expired', clearIsAuthenticated);
+
+    return () => {
+      window.removeEventListener('auth:session-expired', clearIsAuthenticated);
+    };
+  }, [clearIsAuthenticated]);
 
   return <>{children}</>;
 };

--- a/components/providers/ThemeProvider.tsx
+++ b/components/providers/ThemeProvider.tsx
@@ -7,16 +7,18 @@ import { useEffect } from 'react';
 function ThemeSyncer() {
   const { setTheme } = useTheme();
   const user = useAuthStore((state) => state.user);
+  const userTheme = user?.theme as string | undefined;
   const isInitializing = useAuthStore((state) => state.isInitializing);
 
   useEffect(() => {
     if (isInitializing) return;
-    const storedTheme = user?.theme as string | undefined;
+    if (!user) return;
+
     const normalizedTheme =
-      storedTheme === 'light' ? 'oasis' : (storedTheme ?? 'oasis');
+      userTheme === 'light' ? 'oasis' : (userTheme ?? 'oasis');
 
     setTheme(normalizedTheme);
-  }, [user?.theme, setTheme, isInitializing]);
+  }, [user, userTheme, setTheme, isInitializing]);
 
   return null;
 }

--- a/lib/api/api.ts
+++ b/lib/api/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 
 const baseURL = `${process.env.NEXT_PUBLIC_API_URL}/api`;
 
@@ -6,3 +6,72 @@ export const nextServer = axios.create({
   baseURL,
   withCredentials: true,
 });
+
+interface RetryAxiosRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
+
+interface RefreshResponse {
+  success: boolean;
+}
+
+const authRoutesWithoutRefresh = [
+  '/auth/login',
+  '/auth/register',
+  '/auth/logout',
+  '/auth/refresh',
+];
+
+let refreshPromise: Promise<void> | null = null;
+
+function shouldSkipRefresh(url?: string) {
+  if (!url) return false;
+
+  return authRoutesWithoutRefresh.some((route) => url.includes(route));
+}
+
+async function refreshAccessToken() {
+  const { data } = await nextServer.post<RefreshResponse>('/auth/refresh');
+
+  if (!data.success) {
+    throw new Error('Unable to refresh access token');
+  }
+}
+
+function notifySessionExpired() {
+  if (typeof window === 'undefined') return;
+
+  window.dispatchEvent(new Event('auth:session-expired'));
+}
+
+nextServer.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as RetryAxiosRequestConfig | undefined;
+
+    if (
+      typeof window === 'undefined' ||
+      error.response?.status !== 401 ||
+      !originalRequest ||
+      originalRequest._retry ||
+      shouldSkipRefresh(originalRequest.url)
+    ) {
+      return Promise.reject(error);
+    }
+
+    originalRequest._retry = true;
+
+    try {
+      refreshPromise ??= refreshAccessToken().finally(() => {
+        refreshPromise = null;
+      });
+
+      await refreshPromise;
+
+      return nextServer.request(originalRequest);
+    } catch (refreshError) {
+      notifySessionExpired();
+      return Promise.reject(refreshError);
+    }
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1541,7 +1540,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1610,7 +1608,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -2264,7 +2261,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2604,7 +2600,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2672,7 +2667,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2920,8 +2914,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3135,8 +3128,7 @@
     "node_modules/embla-carousel": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
-      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "peer": true
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA=="
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -3388,7 +3380,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3574,7 +3565,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5640,7 +5630,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5671,7 +5660,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6513,7 +6501,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6694,7 +6681,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6860,7 +6846,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -7052,7 +7037,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Зробив точкові правки:


AuthProvider.tsx (line 20): session init тепер у try/catch/finally, setInitialized() гарантовано викликається, помилки checkSession/getMe чистять auth state.

api.ts (line 47): додав axios response interceptor з _retry, пропуском auth routes, одним shared refreshPromise для паралельних 401 і повтором original request після refresh.

refresh route (line 14): прибрав ранній success: true при самому факті наявності accessToken, щоб expired access token реально refresh-ився через refreshToken.

StatusBlock (line 23),
BabyTodayCard (line 26),
TasksReminderCard (line 25),
MomTipCard (line 17): додав isInitializing guards, щоб під час auth init не запускались public week 1 / user-specific запити і не показувався guest/default стан.

ThemeProvider.tsx (line 13): тема більше не скидається у fallback, поки auth ще ініціалізується або user ще null.